### PR TITLE
change comparison to be case insensitive

### DIFF
--- a/Service.cs
+++ b/Service.cs
@@ -46,9 +46,9 @@ namespace DictionaryHelper
 				key = keys.Last();
 			}
 
-			if (DictionaryCache._cache.Any(x => x.Value.Key == key && x.Value.Culture == culture)) {
+			if (DictionaryCache._cache.Any(x => x.Value.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase) && x.Value.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase))) {
 
-				var dict = DictionaryCache._cache.FirstOrDefault(x => x.Value.Key == key && x.Value.Culture == culture);
+				var dict = DictionaryCache._cache.FirstOrDefault(x => x.Value.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase) && x.Value.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
 
 				if (!string.IsNullOrEmpty(dict.Value.Value))
 				{

--- a/Service.cs
+++ b/Service.cs
@@ -46,9 +46,9 @@ namespace DictionaryHelper
 				key = keys.Last();
 			}
 
-			if (DictionaryCache._cache.Any(x => x.Value.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase) && x.Value.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase))) {
+			if (DictionaryCache._cache.Any(x => x.Value.Key.Equals(key, StringComparison.OrdinalIgnoreCase) && x.Value.Culture.Equals(culture, StringComparison.OrdinalIgnoreCase))) {
 
-				var dict = DictionaryCache._cache.FirstOrDefault(x => x.Value.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase) && x.Value.Culture.Equals(culture, StringComparison.InvariantCultureIgnoreCase));
+				var dict = DictionaryCache._cache.FirstOrDefault(x => x.Value.Key.Equals(key, StringComparison.OrdinalIgnoreCase) && x.Value.Culture.Equals(culture, StringComparison.OrdinalIgnoreCase));
 
 				if (!string.IsNullOrEmpty(dict.Value.Value))
 				{


### PR DESCRIPTION
Umbraco's dictionary is case insensitive when it comes to saving dictionary items. 

This means that a user cannot have two dictionary items with the same name with differing cases. E.g.
"Dictionary_Item" exists => "dictionary_item" cannot be created.

Therefore, when comparing the Dictionary cache, the code should not do a straight `==` comparison, and should instead be compared ignoring case.